### PR TITLE
Fix profiles not resolving

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -703,9 +703,9 @@
       }
     },
     "@adraffy/ens-normalize": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.0.tgz",
-      "integrity": "sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q=="
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
+      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw=="
     },
     "@ampproject/remapping": {
       "version": "2.2.1",
@@ -870,13 +870,6 @@
         "@smithy/util-waiter": "^2.0.1",
         "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@aws-sdk/client-sso": {
@@ -917,13 +910,6 @@
         "@smithy/util-retry": "^2.0.0",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@aws-sdk/client-sso-oidc": {
@@ -964,13 +950,6 @@
         "@smithy/util-retry": "^2.0.0",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@aws-sdk/client-sts": {
@@ -1015,13 +994,6 @@
         "@smithy/util-utf8": "^2.0.0",
         "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@aws-sdk/credential-provider-env": {
@@ -1033,13 +1005,6 @@
         "@smithy/property-provider": "^2.0.0",
         "@smithy/types": "^2.0.2",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@aws-sdk/credential-provider-ini": {
@@ -1057,13 +1022,6 @@
         "@smithy/shared-ini-file-loader": "^2.0.0",
         "@smithy/types": "^2.0.2",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@aws-sdk/credential-provider-node": {
@@ -1082,13 +1040,6 @@
         "@smithy/shared-ini-file-loader": "^2.0.0",
         "@smithy/types": "^2.0.2",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@aws-sdk/credential-provider-process": {
@@ -1101,13 +1052,6 @@
         "@smithy/shared-ini-file-loader": "^2.0.0",
         "@smithy/types": "^2.0.2",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@aws-sdk/credential-provider-sso": {
@@ -1122,13 +1066,6 @@
         "@smithy/shared-ini-file-loader": "^2.0.0",
         "@smithy/types": "^2.0.2",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@aws-sdk/credential-provider-web-identity": {
@@ -1140,13 +1077,6 @@
         "@smithy/property-provider": "^2.0.0",
         "@smithy/types": "^2.0.2",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@aws-sdk/middleware-host-header": {
@@ -1158,13 +1088,6 @@
         "@smithy/protocol-http": "^2.0.1",
         "@smithy/types": "^2.0.2",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@aws-sdk/middleware-logger": {
@@ -1175,13 +1098,6 @@
         "@aws-sdk/types": "3.378.0",
         "@smithy/types": "^2.0.2",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@aws-sdk/middleware-recursion-detection": {
@@ -1193,13 +1109,6 @@
         "@smithy/protocol-http": "^2.0.1",
         "@smithy/types": "^2.0.2",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@aws-sdk/middleware-sdk-route53": {
@@ -1210,13 +1119,6 @@
         "@aws-sdk/types": "3.378.0",
         "@smithy/types": "^2.0.2",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@aws-sdk/middleware-sdk-sts": {
@@ -1228,13 +1130,6 @@
         "@aws-sdk/types": "3.378.0",
         "@smithy/types": "^2.0.2",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@aws-sdk/middleware-signing": {
@@ -1249,13 +1144,6 @@
         "@smithy/types": "^2.0.2",
         "@smithy/util-middleware": "^2.0.0",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@aws-sdk/middleware-user-agent": {
@@ -1268,13 +1156,6 @@
         "@smithy/protocol-http": "^2.0.1",
         "@smithy/types": "^2.0.2",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@aws-sdk/token-providers": {
@@ -1288,13 +1169,6 @@
         "@smithy/shared-ini-file-loader": "^2.0.0",
         "@smithy/types": "^2.0.2",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@aws-sdk/types": {
@@ -1304,13 +1178,6 @@
       "requires": {
         "@smithy/types": "^2.0.2",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@aws-sdk/util-endpoints": {
@@ -1320,13 +1187,6 @@
       "requires": {
         "@aws-sdk/types": "3.378.0",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@aws-sdk/util-locate-window": {
@@ -1335,13 +1195,6 @@
       "integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
       "requires": {
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@aws-sdk/util-user-agent-browser": {
@@ -1353,13 +1206,6 @@
         "@smithy/types": "^2.0.2",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@aws-sdk/util-user-agent-node": {
@@ -1371,13 +1217,6 @@
         "@smithy/node-config-provider": "^2.0.1",
         "@smithy/types": "^2.0.2",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@aws-sdk/util-utf8-browser": {
@@ -1394,13 +1233,6 @@
       "integrity": "sha512-TqELu4mOuSIKQCqj63fGVs86Yh+vBx5nHRpWKNUNhB2nPTpfbziTs5c1X358be3peVWA4wPxW7Nt53KIg1tnNw==",
       "requires": {
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@babel/code-frame": {
@@ -2858,10 +2690,10 @@
       "dev": true
     },
     "@ethers-ext/provider-multicall": {
-      "version": "git+https://github.com/ethers-io/ext-provider-multicall.git#b66f75eb995d3cdbc20e7b251335ee2db327aa71",
+      "version": "git+https://github.com/ethers-io/ext-provider-multicall.git#ce173e71b796b4ebeaa5d65076951625ef54d658",
       "from": "git+https://github.com/ethers-io/ext-provider-multicall.git",
       "requires": {
-        "ethers": "^6.7.0"
+        "ethers": "^6.13.4"
       }
     },
     "@ethersproject/abi": {
@@ -3571,12 +3403,6 @@
             "is-inside-container": "^1.0.0",
             "is-wsl": "^2.2.0"
           }
-        },
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
-          "dev": true
         }
       }
     },
@@ -3758,13 +3584,6 @@
         "@sentry/types": "7.60.1",
         "@sentry/utils": "7.60.1",
         "tslib": "^2.4.1 || ^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@sentry/core": {
@@ -3775,13 +3594,6 @@
         "@sentry/types": "7.60.1",
         "@sentry/utils": "7.60.1",
         "tslib": "^2.4.1 || ^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@sentry/node": {
@@ -3803,11 +3615,6 @@
           "version": "0.4.2",
           "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
           "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
-        },
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
         }
       }
     },
@@ -3823,13 +3630,6 @@
       "requires": {
         "@sentry/types": "7.60.1",
         "tslib": "^2.4.1 || ^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@sinclair/typebox": {
@@ -3845,13 +3645,6 @@
       "requires": {
         "@smithy/types": "^2.0.2",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@smithy/config-resolver": {
@@ -3863,13 +3656,6 @@
         "@smithy/util-config-provider": "^2.0.0",
         "@smithy/util-middleware": "^2.0.0",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@smithy/credential-provider-imds": {
@@ -3882,13 +3668,6 @@
         "@smithy/types": "^2.0.2",
         "@smithy/url-parser": "^2.0.1",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@smithy/eventstream-codec": {
@@ -3900,13 +3679,6 @@
         "@smithy/types": "^2.0.2",
         "@smithy/util-hex-encoding": "^2.0.0",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@smithy/fetch-http-handler": {
@@ -3919,13 +3691,6 @@
         "@smithy/types": "^2.0.2",
         "@smithy/util-base64": "^2.0.0",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@smithy/hash-node": {
@@ -3937,13 +3702,6 @@
         "@smithy/util-buffer-from": "^2.0.0",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@smithy/invalid-dependency": {
@@ -3953,13 +3711,6 @@
       "requires": {
         "@smithy/types": "^2.0.2",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@smithy/is-array-buffer": {
@@ -3968,13 +3719,6 @@
       "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
       "requires": {
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@smithy/middleware-content-length": {
@@ -3985,13 +3729,6 @@
         "@smithy/protocol-http": "^2.0.1",
         "@smithy/types": "^2.0.2",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@smithy/middleware-endpoint": {
@@ -4004,13 +3741,6 @@
         "@smithy/url-parser": "^2.0.1",
         "@smithy/util-middleware": "^2.0.0",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@smithy/middleware-retry": {
@@ -4025,13 +3755,6 @@
         "@smithy/util-retry": "^2.0.0",
         "tslib": "^2.5.0",
         "uuid": "^8.3.2"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@smithy/middleware-serde": {
@@ -4041,13 +3764,6 @@
       "requires": {
         "@smithy/types": "^2.0.2",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@smithy/middleware-stack": {
@@ -4056,13 +3772,6 @@
       "integrity": "sha512-31XC1xNF65nlbc16yuh3wwTudmqs6qy4EseQUGF8A/p2m/5wdd/cnXJqpniy/XvXVwkHPz/GwV36HqzHtIKATQ==",
       "requires": {
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@smithy/node-config-provider": {
@@ -4074,13 +3783,6 @@
         "@smithy/shared-ini-file-loader": "^2.0.1",
         "@smithy/types": "^2.0.2",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@smithy/node-http-handler": {
@@ -4093,13 +3795,6 @@
         "@smithy/querystring-builder": "^2.0.1",
         "@smithy/types": "^2.0.2",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@smithy/property-provider": {
@@ -4109,13 +3804,6 @@
       "requires": {
         "@smithy/types": "^2.0.2",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@smithy/protocol-http": {
@@ -4125,13 +3813,6 @@
       "requires": {
         "@smithy/types": "^2.0.2",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@smithy/querystring-builder": {
@@ -4142,13 +3823,6 @@
         "@smithy/types": "^2.0.2",
         "@smithy/util-uri-escape": "^2.0.0",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@smithy/querystring-parser": {
@@ -4158,13 +3832,6 @@
       "requires": {
         "@smithy/types": "^2.0.2",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@smithy/service-error-classification": {
@@ -4179,13 +3846,6 @@
       "requires": {
         "@smithy/types": "^2.0.2",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@smithy/signature-v4": {
@@ -4201,13 +3861,6 @@
         "@smithy/util-uri-escape": "^2.0.0",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@smithy/smithy-client": {
@@ -4219,13 +3872,6 @@
         "@smithy/types": "^2.0.2",
         "@smithy/util-stream": "^2.0.1",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@smithy/types": {
@@ -4234,13 +3880,6 @@
       "integrity": "sha512-wcymEjIXQ9+NEfE5Yt5TInAqe1o4n+Nh+rh00AwoazppmUt8tdo6URhc5gkDcOYrcvlDVAZE7uG69nDpEGUKxw==",
       "requires": {
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@smithy/url-parser": {
@@ -4251,13 +3890,6 @@
         "@smithy/querystring-parser": "^2.0.1",
         "@smithy/types": "^2.0.2",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@smithy/util-base64": {
@@ -4267,13 +3899,6 @@
       "requires": {
         "@smithy/util-buffer-from": "^2.0.0",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@smithy/util-body-length-browser": {
@@ -4282,13 +3907,6 @@
       "integrity": "sha512-JdDuS4ircJt+FDnaQj88TzZY3+njZ6O+D3uakS32f2VNnDo3vyEuNdBOh/oFd8Df1zSZOuH1HEChk2AOYDezZg==",
       "requires": {
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@smithy/util-body-length-node": {
@@ -4297,13 +3915,6 @@
       "integrity": "sha512-ZV7Z/WHTMxHJe/xL/56qZwSUcl63/5aaPAGjkfynJm4poILjdD4GmFI+V+YWabh2WJIjwTKZ5PNsuvPQKt93Mg==",
       "requires": {
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@smithy/util-buffer-from": {
@@ -4313,13 +3924,6 @@
       "requires": {
         "@smithy/is-array-buffer": "^2.0.0",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@smithy/util-config-provider": {
@@ -4328,13 +3932,6 @@
       "integrity": "sha512-xCQ6UapcIWKxXHEU4Mcs2s7LcFQRiU3XEluM2WcCjjBtQkUN71Tb+ydGmJFPxMUrW/GWMgQEEGipLym4XG0jZg==",
       "requires": {
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@smithy/util-defaults-mode-browser": {
@@ -4346,13 +3943,6 @@
         "@smithy/types": "^2.0.2",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@smithy/util-defaults-mode-node": {
@@ -4366,13 +3956,6 @@
         "@smithy/property-provider": "^2.0.1",
         "@smithy/types": "^2.0.2",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@smithy/util-hex-encoding": {
@@ -4381,13 +3964,6 @@
       "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
       "requires": {
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@smithy/util-middleware": {
@@ -4396,13 +3972,6 @@
       "integrity": "sha512-eCWX4ECuDHn1wuyyDdGdUWnT4OGyIzV0LN1xRttBFMPI9Ff/4heSHVxneyiMtOB//zpXWCha1/SWHJOZstG7kA==",
       "requires": {
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@smithy/util-retry": {
@@ -4412,13 +3981,6 @@
       "requires": {
         "@smithy/service-error-classification": "^2.0.0",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@smithy/util-stream": {
@@ -4434,13 +3996,6 @@
         "@smithy/util-hex-encoding": "^2.0.0",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@smithy/util-uri-escape": {
@@ -4449,13 +4004,6 @@
       "integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
       "requires": {
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@smithy/util-utf8": {
@@ -4465,13 +4013,6 @@
       "requires": {
         "@smithy/util-buffer-from": "^2.0.0",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@smithy/util-waiter": {
@@ -4482,13 +4023,6 @@
         "@smithy/abort-controller": "^2.0.1",
         "@smithy/types": "^2.0.2",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
       }
     },
     "@symfony/webpack-encore": {
@@ -4730,9 +4264,12 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.38",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.38.tgz",
-      "integrity": "sha512-5jY9RhV7c0Z4Jy09G+NIDTsCZ5G0L5n+Z+p+Y7t5VJHM30bgwzSjVtlcBxqAj+6L/swIlvtOSzr8rBk/aNyV2g=="
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "requires": {
+        "undici-types": "~6.19.2"
+      }
     },
     "@types/pbkdf2": {
       "version": "3.1.0",
@@ -8024,33 +7561,28 @@
       }
     },
     "ethers": {
-      "version": "6.8.1",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.8.1.tgz",
-      "integrity": "sha512-iEKm6zox5h1lDn6scuRWdIdFJUCGg3+/aQWu0F4K0GVyEZiktFkqrJbRjTn1FlYEPz7RKA707D6g5Kdk6j7Ljg==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.16.0.tgz",
+      "integrity": "sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==",
       "requires": {
-        "@adraffy/ens-normalize": "1.10.0",
+        "@adraffy/ens-normalize": "1.10.1",
         "@noble/curves": "1.2.0",
         "@noble/hashes": "1.3.2",
-        "@types/node": "18.15.13",
+        "@types/node": "22.7.5",
         "aes-js": "4.0.0-beta.5",
-        "tslib": "2.4.0",
-        "ws": "8.5.0"
+        "tslib": "2.7.0",
+        "ws": "8.17.1"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "18.15.13",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
-          "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q=="
-        },
         "aes-js": {
           "version": "4.0.0-beta.5",
           "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
           "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
         },
         "ws": {
-          "version": "8.5.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
-          "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg=="
+          "version": "8.17.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+          "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ=="
         }
       }
     },
@@ -13017,14 +12549,6 @@
       "requires": {
         "@pkgr/utils": "^2.3.1",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
-          "dev": true
-        }
       }
     },
     "tapable": {
@@ -13232,9 +12756,9 @@
       }
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
     },
     "tsscmp": {
       "version": "1.0.6",
@@ -13301,6 +12825,11 @@
       "requires": {
         "random-bytes": "~1.0.0"
       }
+    },
+    "undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@vue/compiler-sfc": "^3.3.4",
     "@vue/tsconfig": "^0.4.0",
     "axios": "^1.5.1",
-    "ethers": "^6.8.1",
+    "ethers": "^6.16.0",
     "proxy-addr": "^2.0.7",
     "punycode": "^2.3.0",
     "reflect-metadata": "^0.1.13",

--- a/services/EnsService.ts
+++ b/services/EnsService.ts
@@ -10,7 +10,6 @@ import { MulticallProvider } from '@ethers-ext/provider-multicall'
 
 const APP_BSKY = '_atproto'
 const APP_BSKY_ALT = '_atproto.'
-const RPC_THROTTLE_MS = 1000
 
 const textRecordKeys = [
   'avatar',
@@ -123,7 +122,6 @@ export default class EnsService {
     }
 
     // Load ENS Text Records
-    await new Promise((resolve) => setTimeout(resolve, RPC_THROTTLE_MS))
     let allTextRecords = await this.getAllTextRecordsManually(provider, domain, resolver);
 
     // modify records based on custom text keys, e.g. _atproto
@@ -164,7 +162,6 @@ export default class EnsService {
     );
 
     // Load All Addresses
-    await new Promise((resolve) => setTimeout(resolve, RPC_THROTTLE_MS))
     let allAddresses = await this.getAllAddresses(provider, domain, resolver);
 
     this.textRecordValues['wallets'] = [];
@@ -346,9 +343,26 @@ export default class EnsService {
     )
     const node = namehash(name)
 
+    // A CALL_EXCEPTION means the resolver reverted (e.g. it predates addr(bytes32,uint256)
+    // support) — treat as unset. Anything else is a provider failure and must throw, so
+    // callers don't cache an empty wallet list as if the lookup succeeded.
+    let providerError: any = null
     const values = await Promise.all(
-      this.wallets.map((wallet) => addrContract.addr(node, wallet['key']).catch(() => null))
+      this.wallets.map((wallet) =>
+        addrContract.addr(node, wallet['key']).catch((err) => {
+          if (err?.code !== 'CALL_EXCEPTION') {
+            providerError = err
+          }
+          return null
+        })
+      )
     )
+
+    if (providerError) {
+      console.log(`ERROR on getAllAddresses() for ${name}:`, providerError)
+      Sentry.captureException(`ERROR on getAllAddresses() for ${name}: ${providerError}`)
+      throw providerError
+    }
 
     return this.wallets.reduce((accum, wallet, index) => {
       const value = values[index]

--- a/services/EnsService.ts
+++ b/services/EnsService.ts
@@ -4,7 +4,7 @@ import Logger from '@ioc:Adonis/Core/Logger'
 import Route53Service from './Route53Service'
 import * as Sentry from '@sentry/node'
 import sentryConfig from '../config/sentry'
-import { InfuraProvider, Contract, namehash, toNumber } from 'ethers'
+import { AlchemyProvider, Contract, namehash } from 'ethers'
 import { formatsByCoinType } from '@ensdomains/address-encoder'
 import { MulticallProvider } from '@ethers-ext/provider-multicall'
 
@@ -74,6 +74,10 @@ export default class EnsService {
 
   constructor() {}
 
+  private getProvider() {
+    return new AlchemyProvider('mainnet', Env.get('ALCHEMY_API'))
+  }
+
   public async getAllDomainAddresses(domain) {
     if (Env.get('REDIS_ENABLED')) {
       let cachedRecord = await Redis.get(`${this.CACHE_KEY_PREFIX_ADDRESS}${domain}`)
@@ -82,7 +86,7 @@ export default class EnsService {
       }
     }
 
-    const provider = new InfuraProvider('homestead', Env.get('INFURA_PROJECT_ID'), Env.get('INFURA_PROJECT_SECRET'))
+    const provider = this.getProvider()
     let addresses = await this.getAllAddresses(provider, domain)
     if (Env.get('REDIS_ENABLED')) {
       await Redis.setex(
@@ -106,7 +110,7 @@ export default class EnsService {
     }
 
     // Bootstrap resolver + provider
-    const provider = new InfuraProvider('homestead', Env.get('INFURA_PROJECT_ID'), Env.get('INFURA_PROJECT_SECRET'));
+    const provider = this.getProvider()
 
     let resolver = await provider.getResolver(domain).catch((err) => {
       console.log(`ERROR on getResolver() for ${domain}:`, err)
@@ -319,11 +323,6 @@ export default class EnsService {
   }
 
   async getAllAddresses(provider, name, resolver = null) {
-
-    const abi = [
-      "event AddressChanged(bytes32 indexed node, uint256 coinType, bytes newAddress)"
-    ];
-
     if (!resolver) {
       resolver = await provider.getResolver(name)
     }
@@ -332,57 +331,40 @@ export default class EnsService {
       return null
     }
 
-    const contract = new Contract(resolver.address, abi, provider);
+    // Query addr(node, coinType) directly for the known coin types, batched into a single
+    // RPC request via MulticallProvider — same pattern as getAllTextRecordsManually.
+    // This replaces the previous AddressChanged event-log scan, which required eth_getLogs
+    // over the full chain history: Alchemy's free tier rejects ranges over 10 blocks, and it
+    // was the most credit-expensive call on Infura (255 credits per eth_getLogs).
+    // addr() returns the same bytes as the AddressChanged log payload, so the output shape
+    // is unchanged.
+    const mcProvider = new MulticallProvider(provider)
+    const addrContract = new Contract(
+      resolver.address,
+      ['function addr(bytes32 node, uint256 coinType) view returns (bytes)'],
+      mcProvider
+    )
+    const node = namehash(name)
 
-    // Get all the TextChanged logs for the name on its resolver
-    const logs = await contract.queryFilter(contract.filters.AddressChanged(namehash(name)));
+    const values = await Promise.all(
+      this.wallets.map((wallet) => addrContract.addr(node, wallet['key']).catch(() => null))
+    )
 
+    return this.wallets.reduce((accum, wallet, index) => {
+      const value = values[index]
 
-     // Get the *unique* keys
-     const coinTypes = [
-      ...(new Set(logs.map((log) => {
-        return {
-        // @ts-ignore
-        'coinType': toNumber(log.args.coinType),
-        // @ts-ignore
-        'value': log.args.newAddress,
-      }
-    })))
-    ];
-
-    // only return last address for each coin type coinType
-    const result = Object.values(
-      coinTypes.reduce((accumulator, item) => {
-        const { coinType, ...rest } = item;
-        return {
-          ...accumulator,
-          [coinType]: { coinType, ...rest }
-        };
-      }, {})
-    );
-
-    // Return a nice dictionary of the key/value pairs
-    return result.reduce((accum, key, index) => {
-        key = key;
-        const value = result[index];
-        if (value != null) {
-          // @ts-ignore
-          let AddressDefinition = this.wallets.find((wallet) => wallet.key === value.coinType)
-
-          // @ts-ignore
-          accum[value.coinType] = {
-            // @ts-ignore
-            'coinType': value.coinType,
-            // @ts-ignore
-            'value': value.value,
-            // @ts-ignore
-            'name': formatsByCoinType[value.coinType].name,
-            // @ts-ignore
-            'longName': (AddressDefinition && AddressDefinition.name) ?? formatsByCoinType[value.coinType].name
-          }
+      // '0x' means the coin type is not set on the resolver
+      if (value != null && value !== '0x') {
+        const coinType = wallet['key']
+        accum[coinType] = {
+          'coinType': coinType,
+          'value': value,
+          'name': formatsByCoinType[coinType].name,
+          'longName': wallet['name'] ?? formatsByCoinType[coinType].name
         }
-        return accum;
-    }, { });
+      }
+      return accum
+    }, {})
   }
 
 }


### PR DESCRIPTION
## Summary

ENS profiles stopped resolving on first (uncached) view: Infura began returning `-32603 Internal error` for every `eth_call` on our project, which breaks all ENS resolution (resolver lookup, text records, addresses). Confirmed provider-side: the identical request fails via direct curl to Infura and succeeds on Alchemy. This PR switches ENS resolution to Alchemy and removes our dependence on the RPC calls that made the app fragile in the first place.

## Changes

**Provider switch (Infura → Alchemy).** Provider construction is now centralized in a single `getProvider()` helper instead of being duplicated at two call sites — that duplication is how the previous Alchemy switch (April, c9beb73) silently regressed back to Infura during the multicall revert churn.

**ethers 6.8.1 → 6.16.0.** Required for the switch: ethers 6.8.1 hardcodes Alchemy's decommissioned `eth-mainnet.alchemyapi.io` hostname (DNS no longer resolves); 6.16.0 targets the current `eth-mainnet.g.alchemy.com`. This also satisfies `@ethers-ext/provider-multicall`'s declared requirement of ethers `^6.13.4`, which 6.8.1 never met. The lockfile pins the multicall extension to an exact commit.

**`getAllAddresses()` rewritten without `eth_getLogs`.** Previously it discovered wallet addresses by scanning `AddressChanged` event logs from block 0 — Alchemy's free tier rejects ranges over 10 blocks, and it was our most credit-expensive call on Infura (255 credits per request). It now queries `addr(node, coinType)` for the supported coin types (BTC, LTC, DOGE, MONA, ETH), batched into a single RPC request via `MulticallProvider`, mirroring the existing text-records pattern. Output shape to the frontend is unchanged.

**Provider failures now fail loudly instead of poisoning the cache.** Per-coin `addr()` reverts (`CALL_EXCEPTION`, e.g. resolvers that predate EIP-2304) are treated as "address not set", but network/server-level provider errors are logged, captured to Sentry, and thrown — so a transient provider outage returns an error instead of caching an empty wallet list in Redis for the full TTL.

**Removed the 2×1s `RPC_THROTTLE_MS` sleeps.** They paced requests for Infura's credits/sec limit; with batched multicall on Alchemy they were pure latency. Uncached profile loads dropped from ~3.0s to ~1.5s.

## Behavior notes

Address lookup now covers the 5 supported coin types only. Coin types outside that list were previously displayed, but as raw unencoded bytes (e.g. a Solana record rendered as a hex string, not a valid address), so no working functionality is lost. Supporting more coins later is one entry in the list — each is an extra call in the same batch.

On Node 14, ethers 6.16 logs a harmless `ReferenceError: AbortController is not defined` stack trace per RPC request (it catches and falls back internally; functionality is unaffected). Fixable later with a small polyfill or Node upgrade — intentionally out of scope here.

## Verification

Fresh (uncached) end-to-end resolution against mainnet for maaria.eth and vitalik.eth: full text records and wallet addresses, `provider_error: false`, no errors in logs. Lockfile audited: all new packages resolve from registry.npmjs.org with integrity hashes; the one git dependency is commit-pinned to the official ethers-io org.
